### PR TITLE
Fix import python3 compatibility.

### DIFF
--- a/perception/primesense_sensor.py
+++ b/perception/primesense_sensor.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 import os
 
-from constants import MM_TO_METERS, INTR_EXTENSION
+from .constants import MM_TO_METERS, INTR_EXTENSION
 try:
     from primesense import openni2
 except:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 import unittest
 
-from constants import *
+from .constants import *
 from perception import Image, ColorImage, DepthImage, BinaryImage, SegmentationImage, GrayscaleImage, IrImage, PointCloudImage, NormalCloudImage
 
 class TestImage(unittest.TestCase):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 import logging
 import numpy as np
 
-from constants import *
+from .constants import *
 
 from autolab_core import RigidTransform, PointCloud, NormalCloud
 from perception import PointToPlaneICPSolver, PointToPlaneFeatureMatcher


### PR DESCRIPTION
Running `python setup.py test` using python3 resulted in erros due to not finding the constants module. Applied changes fix this python3 compatibility issue.