### PR TITLE
Remove dependency on scipy.misc image ops.

### DIFF
--- a/perception/image.py
+++ b/perception/image.py
@@ -13,7 +13,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import PIL.Image as PImage
 
-import scipy.misc as sm
 import scipy.signal as ssg
 import scipy.ndimage.filters as sf
 import scipy.ndimage.interpolation as sni
@@ -26,6 +25,7 @@ import sklearn.mixture as smx
 import scipy.ndimage.filters as sf
 import scipy.spatial.distance as ssd
 import skimage.morphology as morph
+import skimage.transform as skt
 import scipy.ndimage.morphology as snm
 
 from autolab_core import PointCloud, NormalCloud, PointNormalCloud, Box, Contour
@@ -34,6 +34,19 @@ from .constants import *
 BINARY_IM_MAX_VAL = np.iinfo(np.uint8).max
 BINARY_IM_DEFAULT_THRESH = BINARY_IM_MAX_VAL / 2
 
+
+def imresize(image, size, interp="nearest"):
+    skt_interp_map = {"nearest": 0, "bilinear": 1, "bicubic": 4,}
+    if interp in ("lanczos", "cubic"):
+        raise ValueError("\"lanczos\" and \"cubic\" interpolation are no longer supported.")
+
+    if isinstance(size, (tuple, list)):
+        output_shape = size
+    elif isinstance(size, (float)):
+        output_shape = tuple((np.asarray(image.shape)*size).astype(int))
+    elif isinstance(size, (int)):
+        output_shape = tuple((np.asarray(image.shape)*(float(size)/100)).astype(int))
+    return skt.resize(image, output_shape, order=skt_interp_map[interp])
 
 class Image(object):
     """Abstract wrapper class for images.
@@ -1074,7 +1087,7 @@ class ColorImage(Image):
         :obj:`ColorImage`
             The resized image.
         """
-        resized_data = sm.imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp)
         return ColorImage(resized_data, self._frame)
 
     def find_chessboard(self, sx=6, sy=9):
@@ -1542,7 +1555,7 @@ class DepthImage(Image):
         :obj:`DepthImage`
             The resized image.
         """
-        resized_data = sm.imresize(self.data, size, interp=interp, mode='F')
+        resized_data = imresize(self.data, size, interp=interp)
         return DepthImage(resized_data, self._frame)
 
     def threshold(self, front_thresh=0.0, rear_thresh=100.0):
@@ -1924,7 +1937,7 @@ class IrImage(Image):
         :obj:`IrImage`
             The resized image.
         """
-        resized_data = sm.imresize(self._data, size, interp=interp)
+        resized_data = imresize(self._data, size, interp=interp)
         return IrImage(resized_data, self._frame)
 
     @staticmethod
@@ -2030,7 +2043,7 @@ class GrayscaleImage(Image):
         :obj:`GrayscaleImage`
             The resized image.
         """
-        resized_data = sm.imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp)
         return GrayscaleImage(resized_data, self._frame)
 
     def to_color(self):
@@ -2155,7 +2168,7 @@ class BinaryImage(Image):
         :obj:`BinaryImage`
             The resized image.
         """
-        resized_data = sm.imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp)
         return BinaryImage(resized_data, self._frame)
 
     def mask_binary(self, binary_im):
@@ -3281,7 +3294,7 @@ class SegmentationImage(Image):
             Interpolation to use for re-sizing ('nearest', 'lanczos', 'bilinear',
             'bicubic', or 'cubic')
         """
-        resized_data = sm.imresize(self.data, size, interp=interp, mode='L')
+        resized_data = imresize(self.data, size, interp=interp)
         return SegmentationImage(resized_data, self._frame)
 
     @staticmethod
@@ -3367,9 +3380,9 @@ class PointCloudImage(Image):
         :obj:`PointCloudImage`
             The resized image.
         """
-        resized_data_0 = sm.imresize(self._data[:,:,0], size, interp=interp, mode='F')
-        resized_data_1 = sm.imresize(self._data[:,:,1], size, interp=interp, mode='F')
-        resized_data_2 = sm.imresize(self._data[:,:,2], size, interp=interp, mode='F')
+        resized_data_0 = imresize(self._data[:,:,0], size, interp=interp)
+        resized_data_1 = imresize(self._data[:,:,1], size, interp=interp)
+        resized_data_2 = imresize(self._data[:,:,2], size, interp=interp)
         resized_data = np.zeros([resized_data_0.shape[0],
                                  resized_data_0.shape[1],
                                  self.channels])

--- a/perception/image.py
+++ b/perception/image.py
@@ -36,9 +36,40 @@ BINARY_IM_DEFAULT_THRESH = BINARY_IM_MAX_VAL / 2
 
 
 def imresize(image, size, interp="nearest"):
-    skt_interp_map = {"nearest": 0, "bilinear": 1, "bicubic": 4,}
+    """Wrapper over `skimage.transform.resize` to mimic `scipy.misc.imresize`.
+
+    Since `scipy.misc.imresize` has been removed in version 1.3.*, instead use
+    `skimage.transform.resize`. The "lanczos" and "cubic" interpolation methods
+    are not supported by `skimage.transform.resize`, however there is now
+    "biquadratic", "biquartic", and "biquintic".
+
+    Parameters
+    ----------
+    image : :obj:`numpy.ndarray`
+        The image to resize.
+
+    size : int, float, or tuple
+        * int   - Percentage of current size.
+        * float - Fraction of current size.
+        * tuple - Size of the output image.
+
+    interp : :obj:`str`, optional
+        Interpolation to use for re-sizing ("neartest", "bilinear", 
+        "biquadratic", "bicubic", "biquartic", "biquintic"). Default is
+        "nearest".
+
+    Returns
+    -------
+    :obj:`np.ndarray`
+        The resized image.
+    """
+    skt_interp_map = {"nearest": 0, "bilinear": 1, "biquadratic": 2,
+                      "bicubic": 3, "biquartic": 4, "biquintic": 5}
     if interp in ("lanczos", "cubic"):
-        raise ValueError("\"lanczos\" and \"cubic\" interpolation are no longer supported.")
+        raise ValueError("\"lanczos\" and \"cubic\""
+                         " interpolation are no longer supported.")
+    assert interp in skt_interp_map, ("Interpolation \"{}\" not"
+                                      " supported.".format(interp))
 
     if isinstance(size, (tuple, list)):
         output_shape = size
@@ -46,7 +77,11 @@ def imresize(image, size, interp="nearest"):
         output_shape = tuple((np.asarray(image.shape)*size).astype(int))
     elif isinstance(size, (int)):
         output_shape = tuple((np.asarray(image.shape)*(float(size)/100)).astype(int))
+    else:
+        raise ValueError("Invalid type for size \"{}\".".format(type(size)))
+
     return skt.resize(image, output_shape, order=skt_interp_map[interp])
+
 
 class Image(object):
     """Abstract wrapper class for images.

--- a/perception/image.py
+++ b/perception/image.py
@@ -80,8 +80,11 @@ def imresize(image, size, interp="nearest"):
     else:
         raise ValueError("Invalid type for size \"{}\".".format(type(size)))
 
-    return skt.resize(image, output_shape, order=skt_interp_map[interp])
-
+    return skt.resize(image,
+                      output_shape,
+                      order=skt_interp_map[interp],
+                      anti_aliasing=False,
+                      mode="constant")
 
 class Image(object):
     """Abstract wrapper class for images.

--- a/perception/image.py
+++ b/perception/image.py
@@ -74,9 +74,13 @@ def imresize(image, size, interp="nearest"):
     if isinstance(size, (tuple, list)):
         output_shape = size
     elif isinstance(size, (float)):
-        output_shape = tuple((np.asarray(image.shape)*size).astype(int))
+        np_shape = np.asarray(image.shape).astype(np.float32)
+        np_shape[0:2] *= size
+        output_shape = tuple(np_shape.astype(int))
     elif isinstance(size, (int)):
-        output_shape = tuple((np.asarray(image.shape)*(float(size)/100)).astype(int))
+        np_shape = np.asarray(image.shape).astype(np.float32)
+        np_shape[0:2] *= size / 100.0
+        output_shape = tuple(np_shape.astype(int))
     else:
         raise ValueError("Invalid type for size \"{}\".".format(type(size)))
 

--- a/perception/image.py
+++ b/perception/image.py
@@ -1125,7 +1125,7 @@ class ColorImage(Image):
         :obj:`ColorImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
         return ColorImage(resized_data, self._frame)
 
     def find_chessboard(self, sx=6, sy=9):
@@ -1593,7 +1593,7 @@ class DepthImage(Image):
         :obj:`DepthImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp).astype(np.float32)
         return DepthImage(resized_data, self._frame)
 
     def threshold(self, front_thresh=0.0, rear_thresh=100.0):
@@ -1975,7 +1975,7 @@ class IrImage(Image):
         :obj:`IrImage`
             The resized image.
         """
-        resized_data = imresize(self._data, size, interp=interp)
+        resized_data = imresize(self._data, size, interp=interp).astype(np.uint16)
         return IrImage(resized_data, self._frame)
 
     @staticmethod
@@ -2081,7 +2081,7 @@ class GrayscaleImage(Image):
         :obj:`GrayscaleImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
         return GrayscaleImage(resized_data, self._frame)
 
     def to_color(self):
@@ -2206,7 +2206,7 @@ class BinaryImage(Image):
         :obj:`BinaryImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
         return BinaryImage(resized_data, self._frame)
 
     def mask_binary(self, binary_im):
@@ -3332,7 +3332,7 @@ class SegmentationImage(Image):
             Interpolation to use for re-sizing ('nearest', 'lanczos', 'bilinear',
             'bicubic', or 'cubic')
         """
-        resized_data = imresize(self.data, size, interp=interp)
+        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
         return SegmentationImage(resized_data, self._frame)
 
     @staticmethod
@@ -3418,9 +3418,9 @@ class PointCloudImage(Image):
         :obj:`PointCloudImage`
             The resized image.
         """
-        resized_data_0 = imresize(self._data[:,:,0], size, interp=interp)
-        resized_data_1 = imresize(self._data[:,:,1], size, interp=interp)
-        resized_data_2 = imresize(self._data[:,:,2], size, interp=interp)
+        resized_data_0 = imresize(self._data[:,:,0], size, interp=interp).astype(np.float32)
+        resized_data_1 = imresize(self._data[:,:,1], size, interp=interp).astype(np.float32)
+        resized_data_2 = imresize(self._data[:,:,2], size, interp=interp).astype(np.float32)
         resized_data = np.zeros([resized_data_0.shape[0],
                                  resized_data_0.shape[1],
                                  self.channels])


### PR DESCRIPTION
`scipy.misc` image operations have been removed in version 1.3.0+. The only dependency seemed to be `scipy.misc.imresize` in `image.py` and this has been ported over to `skimage.transform.resize`. It can also be done directly through PIL, but this seems more involved. *Needs to be properly tested for equivalent functionality-seems reasonable from a few initial use cases.*