### PR TITLE
Fixed ColorImage binary resize problem

### DIFF
--- a/perception/image.py
+++ b/perception/image.py
@@ -1129,8 +1129,8 @@ class ColorImage(Image):
         :obj:`ColorImage`
             The resized image.
         """
-        resized_data = imresize(self.data, size, interp=interp).astype(np.uint8)
-        return ColorImage(resized_data, self._frame)
+        resized_data = imresize(self.data.astype(np.float32), size, interp=interp)
+        return ColorImage(resized_data.astype(np.uint8), self._frame)
 
     def find_chessboard(self, sx=6, sy=9):
         """Finds the corners of an sx X sy chessboard in the image.


### PR DESCRIPTION
This pull request fixes the `ColorImage.resize()` function so that it doesn't output a black image when a `uint8` image is resized.

See issue #20 